### PR TITLE
Remove unnecessary annotation processing hacks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,14 @@
 {
-  "java.autobuild.enabled": true,
   "java.import.gradle.enabled": true,
+  "java.autobuild.enabled": false,
   "java.configuration.updateBuildConfiguration": "automatic",
-  "java.import.generatesMetadataFilesAtProjectRoot": true,
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true,
-    "bin/": true,
-    "**/.classpath": true,
-    "**/.project": true,
-    "**/.settings": true,
-    "**/.factorypath": true
+    "**/.settings": true
   },
   "wpilib.selectDefaultSimulateExtension": true,
   "java.test.config": [
@@ -30,5 +25,6 @@
     "coverage-gutters.coverageFileNames": [
         "jacocoTestReport.xml"
     ],
-    "problems.decorations.enabled": true
+    "problems.decorations.enabled": true,
+    "java.jdt.ls.vmargs": "-XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xmx2G -Xms100m -Xlog:disable"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
 
 plugins {
     id "java"
-    id "eclipse"
-    id "com.diffplug.eclipse.apt" version "3.40.0"
     id "edu.wpi.first.GradleRIO" version "2023.1.1" 
     id 'checkstyle'
     id 'jacoco'
@@ -88,7 +86,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
 
-    implementation "xbot.common:scl"
+    implementation project(':SeriouslyCommonLib')
     implementation group: 'log4j', name: 'log4j', version: '1.2.17'
     implementation group: 'org.json', name:'json', version: '20220924'
     
@@ -139,40 +137,6 @@ task('copyResources') {
     }
 }
 
-tasks.getByName('eclipseJdtApt') {
-    dependsOn gradle.includedBuilds*.task(':eclipseJdtApt')
-}
-tasks.getByName('eclipseJdt') {
-    dependsOn gradle.includedBuilds*.task(':eclipseJdt')
-}
-tasks.getByName('eclipseFactorypath') {
-    dependsOn gradle.includedBuilds*.task(':eclipseFactorypath')
-}
-eclipse {
-	// re-generate APT configuration on Gradle project synchronisation
-	//synchronizationTasks eclipseJdtApt, eclipseJdt, eclipseFactorypath
-
-	//jdt.apt {
-    //    genSrcDir = file('bin/generated/sources/annotationProcessor/java/main')
-    //    genTestSrcDir = file('bin/generated/sources/annotationProcessor/java/test')
-    //}
-
-    classpath.file {
-        //beforeMerged { classpath -> 
-        //    sourceSets.main.java.srcDirs += "bin/generated/sources/annotationProcessor/java/main"
-        //    sourceSets.test.java.srcDirs += "bin/generated/sources/annotationProcessor/java/test"
-        //}
-
-        //whenMerged { classpath ->
-        //    classpath.entries.each { entry -> 
-        //        if (entry.path.contains('bin/generated')) {
-        //            entry.entryAttributes['ignore_optional_problems'] = true
-        //        }
-        //    }
-        //}
-    }
-}
-
 checkstyle {
     toolVersion = '8.7'
     configFile = file('SeriouslyCommonLib/xbotcheckstyle.xml')
@@ -190,14 +154,6 @@ test {
     reports {
         junitXml.required = true
     }               
-}
-
-// force test project in SCL to compile so Dagger generation runs
-tasks.getByName('compileTestJava') {
-    dependsOn gradle.includedBuilds*.task(':compileTestJava')
-}
-tasks.getByName('clean') {
-    dependsOn gradle.includedBuilds*.task(':clean')
 }
 
 tasks.withType(Test) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,8 +26,4 @@ pluginManagement {
     }
 }
 
-includeBuild('./SeriouslyCommonLib') {
-    dependencySubstitution {
-        substitute module('xbot.common:scl') with project(':')
-    }
-}
+include(':SeriouslyCommonLib')


### PR DESCRIPTION
vscode-java added built-in annotation processing support so we don't need the hacks anymore.

Unfortunately there's still periodic desyncs where deleting "bin" is necessary. The most convenient way to do that is to keep it visible in vscode, so remove the filter that hides warnings.