### PR TITLE
Setting the version of java via gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,12 @@ task('copyResources') {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 checkstyle {
     toolVersion = '10.6.0'
     configFile = file('SeriouslyCommonLib/xbotcheckstyle.xml')


### PR DESCRIPTION
I've accidentally deployed to the robot using java 21 since that's what my language server uses, and I've had students have issues with getting the "right" java version installed.

Excerpt:

> Using Java toolchains allows Gradle to automatically download and manage the required JDK version for your build. It ensures that the correct Java version is used for both compilation and execution.

https://docs.gradle.org/current/userguide/toolchains.html#sec:using-java-toolchains